### PR TITLE
Add version flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/mdsauce/schelper/version"
 	"github.com/spf13/cobra"
 )
 
@@ -32,6 +33,7 @@ problems and their suggested resolutions or next steps to gather more info.`,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
 	//	Run: func(cmd *cobra.Command, args []string) { },
+	Version: fmt.Sprintf("%s", version.Version),
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -54,6 +56,8 @@ func init() {
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	// rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+	rootCmd.Flags().BoolP("version", "v", false, "Print version information")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,6 @@
+package version
+
+// Version of schelper
+var (
+	Version = "1.0.3"
+)


### PR DESCRIPTION
This change adds the version flag which is it's own package and has a hardcoded version that needs to be bumped.

I couldn't add version.go to the main directory since it gave me errors when setting the package to main and couldn't have two packages in the root/main directory.